### PR TITLE
feat: implement `git ls-files`

### DIFF
--- a/cmd/lsfiles/main.go
+++ b/cmd/lsfiles/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/mergestat/gitutils/lsfiles"
+)
+
+func main() {
+	args := os.Args[1:]
+	iter, err := lsfiles.Exec(context.Background(), args[0], lsfiles.WithFiles(args[1]))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		if file, err := iter.Next(); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			log.Fatal(err)
+		} else {
+			fmt.Println(file)
+		}
+	}
+
+}

--- a/lsfiles/lsfiles.go
+++ b/lsfiles/lsfiles.go
@@ -1,0 +1,93 @@
+package lsfiles
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+type execOptions struct {
+	Files            string
+	NoEmptyDirectory bool
+}
+
+type Option func(o *execOptions)
+
+// WitFiles corresponds to the first (and only) non-flag argument to git ls-files.
+// It's a pattern for filtering the files to list. See <file> here: https://git-scm.com/docs/git-ls-files
+func WithFiles(files string) Option {
+	return func(o *execOptions) {
+		o.Files = files
+	}
+}
+
+// WithNoEmptyDirectory corresponds to the `--no-empty-directory` flag
+// See here: https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---no-empty-directory
+func WithNoEmptyDirectory(NoEmptyDirectory bool) Option {
+	return func(o *execOptions) {
+		o.NoEmptyDirectory = NoEmptyDirectory
+	}
+}
+
+type iterator struct {
+	scanner *bufio.Scanner
+}
+
+// Next moves the iterator and returns the next file (or error).
+// Iteration is complete when the error returned is io.EOF
+func (i *iterator) Next() (string, error) {
+	if next := i.scanner.Scan(); !next {
+		if err := i.scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", io.EOF
+	} else {
+		return i.scanner.Text(), nil
+	}
+}
+
+// Exec runs `git ls-files` using the os/exec standard library package.
+// It returns an iterator which can be used to retrieve a listing of files in a git repo.
+// See here: https://git-scm.com/docs/git-ls-files
+func Exec(ctx context.Context, repoPath string, options ...Option) (*iterator, error) {
+	o := &execOptions{}
+	for _, option := range options {
+		option(o)
+	}
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return nil, fmt.Errorf("could not find git: %w", err)
+	}
+
+	args := []string{"ls-files"}
+
+	if o.NoEmptyDirectory {
+		args = append(args, "--no-empty-directory")
+	}
+
+	// NOTE: this has to be the last argument in the list
+	if o.Files != "" {
+		args = append(args, o.Files)
+	}
+
+	cmd := exec.CommandContext(ctx, gitPath, args...)
+	cmd.Dir = repoPath
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	iter := &iterator{
+		scanner: bufio.NewScanner(stdout),
+	}
+
+	return iter, nil
+}

--- a/lsfiles/lsfiles_test.go
+++ b/lsfiles/lsfiles_test.go
@@ -1,0 +1,69 @@
+package lsfiles_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mergestat/gitutils/lsfiles"
+)
+
+var (
+	repoPath string = "."
+)
+
+func init() {
+	repoPath = os.Getenv("REPO_PATH")
+	var err error
+	repoPath, err = filepath.Abs(repoPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestBasicOK(t *testing.T) {
+	iter, err := lsfiles.Exec(context.Background(), repoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got strings.Builder
+	for {
+		file, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		got.WriteString(file + "\n")
+	}
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), gitPath, "ls-files")
+	cmd.Dir = repoPath
+
+	w, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Log(string(exitErr.Stderr))
+		}
+		t.Fatal(err)
+	}
+
+	want := string(w)
+
+	if string(want) != got.String() {
+		t.Fatal("mismatch")
+	}
+}


### PR DESCRIPTION
this will be useful when implement `git blame` since it will give us a list of files in a repo that are available to run the `blame` command on