### PR TITLE
fix: add `nil` check to handle edge case

### DIFF
--- a/blame/blame.go
+++ b/blame/blame.go
@@ -158,7 +158,9 @@ func parseLinePorcelain(reader io.Reader) (Result, error) {
 		return nil, err
 	}
 
-	res = append(res, currentBlame)
+	if currentBlame != nil {
+		res = append(res, currentBlame)
+	}
 
 	return res, nil
 }


### PR DESCRIPTION
when there are no lines a file being blamed