### PR TITLE
feat: improve `git log` output parsing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.5
+          go-version: 1.19.1
         id: go
 
       - name: Check out source

--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/mergestat/gitutils/gitlog"
+)
+
+func main() {
+	args := os.Args[1:]
+
+	iter, err := gitlog.Exec(context.Background(), args[0], gitlog.WithStats(false))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		if commit, err := iter.Next(); err != nil {
+			log.Fatal(err)
+		} else {
+			if commit == nil {
+				break
+			}
+			fmt.Print(commit)
+		}
+	}
+}

--- a/gitlog/gitlog.go
+++ b/gitlog/gitlog.go
@@ -16,7 +16,7 @@ import (
 
 const isoDataFmtStr = "2006-01-02T15:04:05-07:00"
 
-// line prefixes for the `raw` formatted output
+// line prefixes used in the format string
 const (
 	commitHashPrefix     = "_H:"
 	treeHashPrefix       = "_T:"
@@ -50,7 +50,7 @@ func buildFormatString() string {
 	return b.String()
 }
 
-// Commit represents a parsed commit from git log
+// Commit represents a commit parsed from git log
 type Commit struct {
 	SHA                string
 	Tree               string

--- a/gitlog/gitlog.go
+++ b/gitlog/gitlog.go
@@ -3,6 +3,7 @@ package gitlog
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,27 +14,52 @@ import (
 	"time"
 )
 
+const isoDataFmtStr = "2006-01-02T15:04:05-07:00"
+
 // line prefixes for the `raw` formatted output
 const (
-	commitPrefix    = "commit "
-	treePrefix      = "tree "
-	parentPrefix    = "parent "
-	authorPrefix    = "author "
-	committerPrefix = "committer "
-	gpgsigPrefix    = "gpgsig "
-	messagePrefix   = "    "
+	commitHashPrefix     = "_H:"
+	treeHashPrefix       = "_T:"
+	parentHashesPrefix   = "_P:"
+	authorNamePrefix     = "_aN:"
+	authorEmailPrefix    = "_aE:"
+	authorDatePrefix     = "_aI:"
+	committerNamePrefix  = "_cN:"
+	committerEmailPrefix = "_cE:"
+	committerDatePrefix  = "_cI:"
+	commitBodyPrefix     = "_B:"
 )
+
+// buildFormatString constructs a format string to pass to `git log`
+func buildFormatString() string {
+	var b strings.Builder
+	b.WriteString(commitHashPrefix + "%H%n")
+	b.WriteString(treeHashPrefix + "%T%n")
+	b.WriteString(parentHashesPrefix + "%P%n")
+
+	b.WriteString(authorNamePrefix + "%aN%n")
+	b.WriteString(authorEmailPrefix + "%aE%n")
+	b.WriteString(authorDatePrefix + "%aI%n")
+
+	b.WriteString(committerNamePrefix + "%cN%n")
+	b.WriteString(committerEmailPrefix + "%cE%n")
+	b.WriteString(committerDatePrefix + "%cI%n")
+
+	b.WriteString(commitBodyPrefix + "%B%n%x00")
+
+	return b.String()
+}
 
 // Commit represents a parsed commit from git log
 type Commit struct {
-	SHA       string
-	Tree      string
-	Parents   []string
-	Author    Event
-	Committer Event
-	GPGSig    string
-	Message   string
-	Stats     []Stat
+	SHA                string
+	Tree               string
+	Parents            []string
+	Author             Event
+	Committer          Event
+	Message            string
+	Stats              []Stat
+	hasTrailingNewline bool
 }
 
 // Event represents the who and when of a commit event
@@ -57,6 +83,7 @@ type execOptions struct {
 	Order        CommitOrder
 	FirstParent  bool
 	M            bool
+	Stats        bool
 }
 
 type CommitOrder string
@@ -106,6 +133,12 @@ func WithM(m bool) Option {
 	}
 }
 
+func WithStats(stats bool) Option {
+	return func(o *execOptions) {
+		o.Stats = stats
+	}
+}
+
 type commitIterator struct {
 	// scanner is a Scanner produced from the Stdout of the `git log ...` command
 	scanner       *bufio.Scanner
@@ -114,14 +147,15 @@ type commitIterator struct {
 }
 
 func (i *commitIterator) readUntilCompleteCommit() (*Commit, error) {
-	var inCommitMessage bool
+	var inCommitBody bool
 	for i.scanner.Scan() {
 		line := i.scanner.Text()
+
 		switch {
-		case strings.HasPrefix(line, commitPrefix):
+		case strings.HasPrefix(line, commitHashPrefix):
 			commitToReturn := i.currentCommit
 			i.currentCommit = &Commit{
-				SHA:       strings.TrimPrefix(line, commitPrefix),
+				SHA:       strings.TrimPrefix(line, commitHashPrefix),
 				Author:    Event{},
 				Committer: Event{},
 				Parents:   []string{},
@@ -129,76 +163,51 @@ func (i *commitIterator) readUntilCompleteCommit() (*Commit, error) {
 			}
 
 			if commitToReturn != nil { // if we're seeing a new commit but already have a current commit, we've finished a commit
-				commitToReturn.Message = strings.TrimLeft(commitToReturn.Message, "\n")
-				commitToReturn.Message = strings.TrimSuffix(commitToReturn.Message, "\n\n")
 				return commitToReturn, nil
 			}
-		case strings.HasPrefix(line, treePrefix):
-			i.currentCommit.Tree = strings.TrimPrefix(line, treePrefix)
-		case strings.HasPrefix(line, parentPrefix):
-			i.currentCommit.Parents = append(i.currentCommit.Parents, strings.TrimPrefix(line, parentPrefix))
-		case strings.HasPrefix(line, authorPrefix):
-			s := strings.TrimPrefix(line, authorPrefix)
-			spl := strings.Split(s, " ")
-
-			tz := spl[len(spl)-1]
-			ts := spl[len(spl)-2]
-			email := strings.Trim(spl[len(spl)-3], "<>")
-			name := strings.Join(spl[:len(spl)-3], " ")
-
-			i.currentCommit.Author.Email = email
-			i.currentCommit.Author.Name = strings.TrimSpace(name)
-
-			its, err := strconv.ParseInt(ts, 10, 64)
-			if err != nil {
+		case strings.HasPrefix(line, treeHashPrefix):
+			i.currentCommit.Tree = strings.TrimPrefix(line, treeHashPrefix)
+		case strings.HasPrefix(line, parentHashesPrefix):
+			i.currentCommit.Parents = append(i.currentCommit.Parents, strings.TrimPrefix(line, parentHashesPrefix))
+		case strings.HasPrefix(line, authorNamePrefix):
+			i.currentCommit.Author.Name = strings.TrimPrefix(line, authorNamePrefix)
+		case strings.HasPrefix(line, authorEmailPrefix):
+			i.currentCommit.Author.Email = strings.TrimPrefix(line, authorEmailPrefix)
+		case strings.HasPrefix(line, authorDatePrefix):
+			s := strings.TrimPrefix(line, authorDatePrefix)
+			if t, err := time.Parse(isoDataFmtStr, s); err != nil {
 				return nil, err
+			} else {
+				i.currentCommit.Author.When = t
 			}
-
-			i.currentCommit.Author.When = time.Unix(its, 0)
-
-			ptz, err := time.Parse("-0700", tz)
-			if err != nil {
+		case strings.HasPrefix(line, committerNamePrefix):
+			i.currentCommit.Committer.Name = strings.TrimPrefix(line, committerNamePrefix)
+		case strings.HasPrefix(line, committerEmailPrefix):
+			i.currentCommit.Committer.Email = strings.TrimPrefix(line, committerEmailPrefix)
+		case strings.HasPrefix(line, committerDatePrefix):
+			s := strings.TrimPrefix(line, committerDatePrefix)
+			if t, err := time.Parse(isoDataFmtStr, s); err != nil {
 				return nil, err
+			} else {
+				i.currentCommit.Committer.When = t
 			}
-			i.currentCommit.Author.When = i.currentCommit.Author.When.In(ptz.Location())
-		case strings.HasPrefix(line, committerPrefix):
-			s := strings.TrimPrefix(line, committerPrefix)
-			spl := strings.Split(s, " ")
-
-			tz := spl[len(spl)-1]
-			ts := spl[len(spl)-2]
-			email := strings.Trim(spl[len(spl)-3], "<>")
-			name := strings.Join(spl[:len(spl)-3], " ")
-
-			i.currentCommit.Committer.Email = email
-			i.currentCommit.Committer.Name = strings.TrimSpace(name)
-
-			its, err := strconv.ParseInt(ts, 10, 64)
-			if err != nil {
-				return nil, err
-			}
-
-			i.currentCommit.Committer.When = time.Unix(its, 0)
-
-			ptz, err := time.Parse("-0700", tz)
-			if err != nil {
-				return nil, err
-			}
-			i.currentCommit.Committer.When = i.currentCommit.Committer.When.In(ptz.Location())
-		case strings.HasPrefix(line, gpgsigPrefix):
-			i.currentCommit.GPGSig += strings.TrimPrefix(line, gpgsigPrefix) + "\n"
-		case strings.HasPrefix(line, messagePrefix):
-			inCommitMessage = true
-			i.currentCommit.Message += strings.TrimPrefix(line, messagePrefix) + "\n"
-		case strings.HasPrefix(line, " "):
-			i.currentCommit.GPGSig += strings.TrimPrefix(line, " ") + "\n"
-		case line == "":
-			if inCommitMessage {
-				i.currentCommit.Message += "\n"
-			}
+		case strings.HasPrefix(line, commitBodyPrefix):
+			inCommitBody = true
+			s := strings.TrimPrefix(line, commitBodyPrefix)
+			i.currentCommit.Message = s + "\n"
+		case strings.HasPrefix(line, string([]byte{0})):
+			inCommitBody = false
 		default:
-			inCommitMessage = false
+			if inCommitBody {
+				i.currentCommit.Message += line + "\n"
+				continue
+			} else {
+				i.currentCommit.hasTrailingNewline = true
+			}
 			s := strings.Split(line, "\t")
+			if len(s) != 3 {
+				continue
+			}
 			var additions int
 			var deletions int
 			var err error
@@ -226,10 +235,6 @@ func (i *commitIterator) readUntilCompleteCommit() (*Commit, error) {
 		}
 	}
 
-	if i.currentCommit != nil {
-		i.currentCommit.Message = strings.TrimLeft(i.currentCommit.Message, "\n")
-		i.currentCommit.Message = strings.TrimSuffix(i.currentCommit.Message, "\n\n")
-	}
 	return i.currentCommit, io.EOF
 }
 
@@ -261,7 +266,7 @@ func Exec(ctx context.Context, repoPath string, options ...Option) (*commitItera
 	}
 
 	args := []string{"log"}
-	args = append(args, "--numstat", "--format=raw", "--no-decorate", "-w")
+	args = append(args, fmt.Sprintf("--format=%s", buildFormatString()), "--no-decorate", "-w")
 	if o.NoMerges {
 		args = append(args, "--no-merges")
 	}
@@ -282,6 +287,10 @@ func Exec(ctx context.Context, repoPath string, options ...Option) (*commitItera
 		args = append(args, o.FileFilter)
 	}
 
+	if o.Stats {
+		args = append(args, "--numstat")
+	}
+
 	cmd := exec.CommandContext(ctx, gitPath, args...)
 	cmd.Dir = repoPath
 
@@ -299,47 +308,59 @@ func Exec(ctx context.Context, repoPath string, options ...Option) (*commitItera
 		return nil, err
 	}
 
+	scanner := bufio.NewScanner(stdout)
+
+	// this is a custom split function based off the default bufio.ScanLines one
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/bufio/scan.go;l=350;drc=18888751828c329ddf5efdd7ec1b39adf0b6ea00
+	// we need to do this because we want to preserve the newlines in commit messages
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.IndexByte(data, '\n'); i >= 0 {
+			// We have a full newline-terminated line.
+			return i + 1, data[0:i], nil
+		}
+		// If we're at EOF, we have a final, non-terminated line. Return it.
+		if atEOF {
+			return len(data), data, nil
+		}
+		// Request more data.
+		return 0, nil, nil
+	})
+
 	iter := &commitIterator{
-		scanner: bufio.NewScanner(stdout),
+		scanner: scanner,
 		stderr:  stderr,
 	}
 
 	return iter, nil
 }
 
-func prefixEveryLine(s, prefix string) string {
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		lines[i] = fmt.Sprintf("%s%s", prefix, line)
-	}
-	return strings.Join(lines, "\n")
-}
-
-// String returns a string representation of a commit that looks like the output of --format=raw
+// String returns a string representation of a commit that looks like the output from the original git log command
+// where --format=... uses the custom format template we define in buildFormatString().
 func (c *Commit) String() string {
-	var output strings.Builder
-	output.WriteString(fmt.Sprintf("commit %s\n", c.SHA))
-	output.WriteString(fmt.Sprintf("tree %s\n", c.Tree))
-	for _, parent := range c.Parents {
-		output.WriteString(fmt.Sprintf("parent %s\n", parent))
-	}
-	output.WriteString(fmt.Sprintf("author %s <%s> %d %s\n", c.Author.Name, c.Author.Email, c.Author.When.Unix(), c.Author.When.Format("-0700")))
-	output.WriteString(fmt.Sprintf("committer %s <%s> %d %s\n", c.Committer.Name, c.Committer.Email, c.Committer.When.Unix(), c.Committer.When.Format("-0700")))
+	var s strings.Builder
 
-	if c.GPGSig != "" {
-		gpgsigLines := strings.Split(c.GPGSig, "\n")
-		output.WriteString(fmt.Sprintf("gpgsig %s\n", gpgsigLines[0]))
+	s.WriteString(fmt.Sprintf("%s%s\n", commitHashPrefix, c.SHA))
+	s.WriteString(fmt.Sprintf("%s%s\n", treeHashPrefix, c.Tree))
+	s.WriteString(fmt.Sprintf("%s%s\n", parentHashesPrefix, strings.Join(c.Parents, " ")))
 
-		output.WriteString(prefixEveryLine(strings.Join(gpgsigLines[1:len(gpgsigLines)-1], "\n"), " "))
-		output.WriteString("\n")
-	}
+	s.WriteString(fmt.Sprintf("%s%s\n", authorNamePrefix, c.Author.Name))
+	s.WriteString(fmt.Sprintf("%s%s\n", authorEmailPrefix, c.Author.Email))
+	s.WriteString(fmt.Sprintf("%s%s\n", authorDatePrefix, c.Author.When.Format(isoDataFmtStr)))
 
-	output.WriteString("\n")
-	output.WriteString(strings.TrimSuffix(prefixEveryLine(c.Message, "    "), "    "))
-	output.WriteString("\n")
+	s.WriteString(fmt.Sprintf("%s%s\n", committerNamePrefix, c.Committer.Name))
+	s.WriteString(fmt.Sprintf("%s%s\n", committerEmailPrefix, c.Committer.Email))
+	s.WriteString(fmt.Sprintf("%s%s\n", committerDatePrefix, c.Committer.When.Format(isoDataFmtStr)))
 
-	if len(c.Stats) > 0 {
-		output.WriteString("\n")
+	message := c.Message
+	// message = strings.TrimSuffix(message, "\n")
+
+	s.WriteString(fmt.Sprintf("%s%s\x00\n", commitBodyPrefix, message))
+
+	if len(c.Stats) > 0 || c.hasTrailingNewline {
+		s.WriteString("\n")
 	}
 
 	for _, stat := range c.Stats {
@@ -351,8 +372,8 @@ func (c *Commit) String() string {
 		if deletions == "-1" {
 			deletions = "-"
 		}
-		output.WriteString(fmt.Sprintf("%s\t%s\t%s\n", additions, deletions, stat.FilePath))
+		s.WriteString(fmt.Sprintf("%s\t%s\t%s\n", additions, deletions, stat.FilePath))
 	}
 
-	return output.String()
+	return s.String()
 }


### PR DESCRIPTION
use a fixed format string (vs a preset like `raw`). This gives us more control over the data we want to parse.

Addresses part of #16 