### PR TITLE
fix: handle stderr error output in `git clone`

### DIFF
--- a/_examples/clone/main.go
+++ b/_examples/clone/main.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"log"
 	"os"
+	"os/exec"
 
 	"github.com/mergestat/gitutils/clone"
 )
 
 func main() {
 	args := os.Args[1:]
-	configTest := map[string]string{"core.eol": "true"}
-	err := clone.Exec(context.Background(), args[0], args[1], clone.WithConfig(configTest))
+	err := clone.Exec(context.Background(), args[0], args[1])
 	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Fatal(string(err.Stderr)+"\n", err)
+		}
 		log.Fatal(err)
 	}
 }

--- a/clone/clone.go
+++ b/clone/clone.go
@@ -479,12 +479,7 @@ func Exec(ctx context.Context, repo, dir string, options ...Option) error {
 
 	cmd := exec.CommandContext(ctx, gitPath, args...)
 
-	_, err = cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
+	if _, err := cmd.Output(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use `.Output()` (and don't set the `cmd.Stderr`) so that we can access the `git` error output in the go error