### PR TITLE
feat: some small updates to the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 # gitutils
 
 This is a Golang library for programmatically working with the `git` command (via the `os/exec` package).
-There are some options for working with git repositories in go:
+In general, the options for working with git repositories in Go look like:
 
   - [`go-git`](https://github.com/go-git/go-git) is a git implementation written in pure Go
   - [`git2go`](https://github.com/libgit2/git2go) are the Golang C-bindings to the `libgit2` project (requires CGO)
   - Shelling out to the `git` command (using the `os/exec` package) and parsing results
 
-This library uses the 3rd option (shelling out to `git`) and provides an abstraction layer to make using the output of various `git` subcommands easier.
+This library uses the 3rd option (shelling out to `git`) and provides an abstraction layer to simplify using the output of various `git` subcommands.
 
 ## Examples
 
@@ -37,5 +37,4 @@ func main() {
 	}
 }
 ```
-
-more examples on the way...
+See more examples in the [examples directory](https://github.com/mergestat/gitutils/tree/main/_examples).

--- a/README.md
+++ b/README.md
@@ -37,4 +37,38 @@ func main() {
 	}
 }
 ```
+
+### Walking the Commit Log
+
+```golang
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/mergestat/gitutils/gitlog"
+)
+
+func main() {
+	iter, err := gitlog.Exec(context.TODO(), "/path/to/some/local/repo", gitlog.WithStats(false))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		if commit, err := iter.Next(); err != nil {
+			log.Fatal(err)
+		} else {
+			if commit == nil {
+				break
+			}
+			fmt.Print(commit)
+		}
+	}
+}
+```
+
 See more examples in the [examples directory](https://github.com/mergestat/gitutils/tree/main/_examples).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # gitutils
 
 This is a Golang library for programmatically working with the `git` command (via the `os/exec` package).
-In general, the options for working with git repositories in Go look like:
+In general, the options for working with git repositories in Go are:
 
   - [`go-git`](https://github.com/go-git/go-git) is a git implementation written in pure Go
   - [`git2go`](https://github.com/libgit2/git2go) are the Golang C-bindings to the `libgit2` project (requires CGO)

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,3 @@
+# `gitutils` Examples
+
+This directory houses various code examples for using packages from `gitutils` in Go code.


### PR DESCRIPTION
Adds another example to the `README`, but defers to linking to the `_examples` directory as the "source of truth"