### PR TITLE
feat: implement more consistent iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -60,12 +62,12 @@ func main() {
 
 	for {
 		if commit, err := iter.Next(); err != nil {
-			log.Fatal(err)
-		} else {
-			if commit == nil {
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			fmt.Print(commit)
+			log.Fatal(err)
+		} else {
+			fmt.Println(commit.SHA)
 		}
 	}
 }

--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -19,12 +21,12 @@ func main() {
 
 	for {
 		if commit, err := iter.Next(); err != nil {
-			log.Fatal(err)
-		} else {
-			if commit == nil {
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			fmt.Print(commit)
+			log.Fatal(err)
+		} else {
+			fmt.Println(commit.SHA)
 		}
 	}
 }

--- a/gitlog/gitlog_test.go
+++ b/gitlog/gitlog_test.go
@@ -2,7 +2,9 @@ package gitlog
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -35,12 +37,12 @@ func TestCount(t *testing.T) {
 
 	var count int
 	for {
-		commit, err := iter.Next()
+		_, err := iter.Next()
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			t.Fatal(err)
-		}
-		if commit == nil {
-			break
 		}
 		count++
 	}
@@ -76,12 +78,12 @@ func TestCountNoMerges(t *testing.T) {
 
 	var count int
 	for {
-		commit, err := iter.Next()
+		_, err := iter.Next()
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			t.Fatal(err)
-		}
-		if commit == nil {
-			break
 		}
 		count++
 	}
@@ -120,10 +122,10 @@ func TestLogOutputWithStats(t *testing.T) {
 	for {
 		commit, err := iter.Next()
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			t.Fatal(err)
-		}
-		if commit == nil {
-			break
 		}
 		got.WriteString(commit.String())
 	}


### PR DESCRIPTION
in the `gitlog` package, use `io.EOF` to indicate that the commit iteration is complete (not the `commit == nil` check).

Should be merged after #28 