### PR TITLE
feat: add `WithMaxCount` option to `gitlog`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Check out source
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Vet
         run: make vet

--- a/gitlog/gitlog.go
+++ b/gitlog/gitlog.go
@@ -83,6 +83,7 @@ type execOptions struct {
 	FirstParent  bool
 	M            bool
 	Stats        bool
+	MaxCount     int
 }
 
 type CommitOrder string
@@ -135,6 +136,12 @@ func WithM(m bool) Option {
 func WithStats(stats bool) Option {
 	return func(o *execOptions) {
 		o.Stats = stats
+	}
+}
+
+func WithMaxCount(n int) Option {
+	return func(o *execOptions) {
+		o.MaxCount = n
 	}
 }
 
@@ -286,6 +293,10 @@ func Exec(ctx context.Context, repoPath string, options ...Option) (*commitItera
 
 	if o.M {
 		args = append(args, "-m")
+	}
+
+	if o.MaxCount > 0 {
+		args = append(args, fmt.Sprintf("--max-count=%d", o.MaxCount))
 	}
 
 	if o.FileFilter != "" {

--- a/gitlog/gitlog_test.go
+++ b/gitlog/gitlog_test.go
@@ -151,7 +151,7 @@ func TestLogOutputWithStats(t *testing.T) {
 	}
 }
 
-func TestLogOutputMaxCount(t *testing.T) {
+func TestLogOutputWithMaxCount(t *testing.T) {
 	wantCount := 7
 
 	iter, err := Exec(context.Background(), repoPath, WithMaxCount(wantCount))

--- a/gitlog/gitlog_test.go
+++ b/gitlog/gitlog_test.go
@@ -150,3 +150,28 @@ func TestLogOutputWithStats(t *testing.T) {
 		t.Fatal("mismatch")
 	}
 }
+
+func TestLogOutputMaxCount(t *testing.T) {
+	wantCount := 7
+
+	iter, err := Exec(context.Background(), repoPath, WithMaxCount(wantCount))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	for {
+		_, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		count++
+	}
+
+	if count != wantCount {
+		t.Fatalf("mismatch in commit counts, got: %d want: %d", count, wantCount)
+	}
+}


### PR DESCRIPTION
Implements use of the `--max-count` flag (https://git-scm.com/docs/git-log#Documentation/git-log.txt---max-countltnumbergt) (`-n`)